### PR TITLE
handle getDir of undefined

### DIFF
--- a/src/worker/directory.js
+++ b/src/worker/directory.js
@@ -71,6 +71,12 @@ Directory.prototype.getDir = function (dir, cb) {
             fs.stat(Path.join(__config.directory.path, dir), function(err, s){
               if(err){
                 Log.print(err)
+                cb({
+                  'mtime': 0,
+                  'totalSize': 0,
+                  'files': []
+                })
+                return
               }
               cb({
                 'mtime': s.mtime,
@@ -85,6 +91,12 @@ Directory.prototype.getDir = function (dir, cb) {
       fs.stat(Path.join(__config.directory.path, dir), function(err, s){
         if(err){
           Log.print(err)
+          cb({
+            'mtime': 0,
+            'totalSize': 0,
+            'files': []
+          })
+          return
         }
         cb({
           'mtime': s.mtime,


### PR DESCRIPTION
```
{ Error: ENOTDIR: not a directory, scandir 'files/somefile/'
    at Error (native)
  errno: -20,
  code: 'ENOTDIR',
  syscall: 'scandir',
  path: 'files/somefile/' }
{ Error: ENOTDIR: not a directory, stat 'files/somefile/'
    at Error (native)
  errno: -20,
  code: 'ENOTDIR',
  syscall: 'stat',
  path: 'files/somefile/' }
/src/worker/directory.js:90
          'mtime': s.mtime,
                    ^

TypeError: Cannot read property 'mtime' of undefined
    at /src/worker/directory.js:90:21
    at FSReqWrap.oncomplete (fs.js:123:15)
```