### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To prevent that you can use [kaffeine](http://kaffeine.herokuapp.com/) to keep y
 
 ## With Docker
 [![Docker Stars](https://img.shields.io/docker/stars/lunik/lunik-torrent.svg)](https://hub.docker.com/r/lunik/lunik-torrent/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/lunik/lunik-torrent.svg)](https://hub.docker.com/r/lunik/lunik-torrent/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/lunik/lunik-torrent.svg)](https://hub.docker.com/r/lunik/lunik-torrent/) [![](https://images.microbadger.com/badges/image/lunik/lunik-torrent.svg)](https://microbadger.com/images/lunik/lunik-torrent "Get your own image badge on microbadger.com")
 
 Create `config.json` following this pattern [config.default](https://raw.githubusercontent.com/Lunik/Lunik-Torrent/master/configs/config.default). Then put it int `/your_config_folder`.
 
@@ -81,3 +81,4 @@ $ curl --data "invitationkey=mykey" http://localhost:5000/auth?todo=invite
 }
 ```
 To register go to `http://localhost:5000/login.html#your_invitation_code`
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [lunik/lunik-torrent](https://hub.docker.com/r/lunik/lunik-torrent/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/lunik/lunik-torrent).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/lunik/lunik-torrent.svg)](https://microbadger.com/images/lunik/lunik-torrent "Get your own image badge on microbadger.com")
