### PR TITLE
don't use clusterjs if 1 duplicata

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,43 @@ var Config = require(Path.join(__base, 'src/worker/config.js'))
 var ConfigWorker = new Config()
 global.__config = ConfigWorker.load(Path.join(__base, 'configs/config.json'))
 
-var cluster = require('cluster')
-var numCPUs = require('os').cpus().length
 
-if (cluster.isMaster) {
+if (__config.server.duplication > 1){
+  var cluster = require('cluster')
+  var numCPUs = require('os').cpus().length
+
+  if (cluster.isMaster) {
+    var Rand = require('crypto-rand')
+    var Crypto = require('crypto-js')
+    var token = Crypto.SHA256(Rand.rand().toString()).toString()
+
+    var Database = require(Path.join(__base, 'src/database/server.js'))
+    var DBPort = process.env.DB_PORT || __config.database.port
+    var DB = new Database(DBPort, token)
+
+    cluster.schedulingPolicy = cluster.SCHED_RR
+    var i = 0
+    while (i < numCPUs && i < __config.server.duplication) {
+      cluster.fork()
+      i++
+    }
+
+    cluster.on('online', function (worker) {
+      worker.send(token)
+    })
+
+    cluster.on('exit', function (worker, code, signal) {
+      console.log('Worker ' + worker.process.pid + ' died')
+      cluster.fork()
+    })
+  } else {
+    var Server = require(Path.join(__base, 'src/controller/main.js'))
+    process.on('message', function (token) {
+      global.__DBtoken = token
+      var ServerWorker = new Server(cluster.worker.id)
+    })
+  }
+} else {
   var Rand = require('crypto-rand')
   var Crypto = require('crypto-js')
   var token = Crypto.SHA256(Rand.rand().toString()).toString()
@@ -21,25 +54,8 @@ if (cluster.isMaster) {
   var DBPort = process.env.DB_PORT || __config.database.port
   var DB = new Database(DBPort, token)
 
-  cluster.schedulingPolicy = cluster.SCHED_RR
-  var i = 0
-  while (i < numCPUs && i < __config.server.duplication) {
-    cluster.fork()
-    i++
-  }
-
-  cluster.on('online', function (worker) {
-    worker.send(token)
-  })
-
-  cluster.on('exit', function (worker, code, signal) {
-    console.log('Worker ' + worker.process.pid + ' died')
-    cluster.fork()
-  })
-} else {
   var Server = require(Path.join(__base, 'src/controller/main.js'))
-  process.on('message', function (token) {
-    global.__DBtoken = token
-    var ServerWorker = new Server(cluster.worker.id)
-  })
+
+  global.__DBtoken = token
+  var ServerWorker = new Server(1)
 }


### PR DESCRIPTION
Some people have issues with memory on small server #229. ClusterJS was killing is childs.
To prevent this, if 1 duplica is chosen, clusterJS is not used.